### PR TITLE
Handling queryString in reverse proxy

### DIFF
--- a/project/src/main/java/com/tek271/reverseProxy/servlet/ProxyFilter.java
+++ b/project/src/main/java/com/tek271/reverseProxy/servlet/ProxyFilter.java
@@ -57,6 +57,10 @@ public class ProxyFilter implements Filter {
   
   private static Tuple2<Mapping, String> mapUrlProxyToHidden(ServletRequest request) {
     String oldUrl = ((HttpServletRequest)request).getRequestURL().toString();
+	String queryString = ((HttpServletRequest)request).getQueryString();  
+	if (queryString != null) {
+		oldUrl += "?"+queryString;
+	}
     return UrlMapper.mapFullUrlProxyToHidden(oldUrl);
   }
   


### PR DESCRIPTION
Hello

Came across a problem with the reverse proxy:
queryString parameters are not passed on through the proxy. 

I have added a quickfix for appending the queryString before passing it on. 
Can you pull this change, or possible implement queryString handling the way you see fit? 
